### PR TITLE
Using React as Web Components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,21 @@
 
 import './App.css'
+import { ICardProps } from './components/Card';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'app-card': ICardProps;
+    }
+  }
+}
 
 function App() {
 
   return (
     <div className="App">
       <h2>React To Web Component</h2>
+      <app-card title="Task One" description="Card Content"/>
     </div>
   )
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,18 @@
+
+
+export interface ICardProps {
+    title:string,
+    description:string
+}
+export const Card = ({
+    title, 
+    description
+}:ICardProps) => {
+
+    return (
+        <div style={{backgroundColor:"lightblue", border:"2px solid gray", color:"black"}}>
+            <h2>{title}</h2>
+            <h4>{description}</h4>
+        </div>
+    )
+}

--- a/src/components/CardWebComponent.tsx
+++ b/src/components/CardWebComponent.tsx
@@ -1,0 +1,18 @@
+import { createElement } from "react"
+import { Card } from "./Card"
+import { createRoot } from "react-dom/client"
+
+
+export class CardWebComponent extends HTMLElement{
+constructor(){
+    super()
+}
+connectedCallback(){
+    createRoot(this).render(createElement(
+        Card, 
+        {title:this.getAttribute("title")!,
+            description:this.getAttribute("description")!
+        }
+    ))
+}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { CardWebComponent } from './components/CardWebComponent'
 
+customElements.define('app-card', CardWebComponent)
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Convert React components into Web Components using react-to-web-component. Angular then treats them like native HTML elements.
Best separation of concerns—Angular and React don’t interfere with each other’s logic.
No need to modify Angular-specific code, making it agnostic to framework updates.
Future-proof solution, allowing a smooth migration from Angular to React over time.
Works with any frontend framework, so the React components can be reused elsewhere.